### PR TITLE
Add feature to set default output device

### DIFF
--- a/examples/set_def_out_dev.rb
+++ b/examples/set_def_out_dev.rb
@@ -1,0 +1,22 @@
+require "coreaudio"
+
+# Select option name device as default output device 
+def set_interface(name)
+	if !name
+		puts 'please enter audio output interface name.'
+		return -1
+	end
+
+	devs = CoreAudio.devices
+
+	tgt = devs.find{|dev| dev.name.index(name)}
+	if !tgt
+		p "no match interface #{name}"
+		return -1
+	end
+
+	CoreAudio.set_default_output_device(tgt)
+	p "select default output audio interface #{tgt.name}"
+end
+
+set_interface(ARGV[0])

--- a/ext/coreaudio.m
+++ b/ext/coreaudio.m
@@ -417,6 +417,34 @@ ca_default_output_device(int argc, VALUE *argv, VALUE mod)
 }
 
 /*
+ * Document-method: CoreAudio.set_default_output_device
+ * call-seq:
+ *   CoreAudio.set_default_output_device(audio_device)
+ *
+ * Set system default audio output device as CoreAudio::AudioDevice object.
+ */
+static VALUE
+ca_set_default_output_device(VALUE self, VALUE device)
+{
+    AudioDeviceID devID = NUM2UINT(rb_ivar_get(device, sym_iv_devid));    
+    AudioObjectPropertyAddress address = PropertyAddress;
+    UInt32 size;
+    OSStatus status;
+
+    address.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+    address.mScope    = kAudioObjectPropertyScopeGlobal;
+    address.mElement  = kAudioObjectPropertyElementMaster;
+
+    status = AudioObjectSetPropertyData(kAudioObjectSystemObject, &address, 0, NULL, sizeof(devID), &devID);
+    if (status != noErr) {
+      rb_raise(rb_eArgError,
+               "coreaudio: set default output deveice failed: %d", status);
+    }
+
+    return Qtrue;
+}
+
+/*
  * Document-class: CoreAudio::OutLoop
  *
  * CoreAudio::OutLoop is an class for loop waveform to output audio stream.
@@ -1130,6 +1158,7 @@ Init_coreaudio_ext(void)
     rb_define_singleton_method(rb_mCoreAudio, "devices", ca_devices, -1);
     rb_define_singleton_method(rb_mCoreAudio, "default_input_device", ca_default_input_device, -1);
     rb_define_singleton_method(rb_mCoreAudio, "default_output_device", ca_default_output_device, -1);
+    rb_define_singleton_method(rb_mCoreAudio, "set_default_output_device", ca_set_default_output_device, 1);
 
     rb_define_method(rb_cOutLoop, "[]=", ca_out_loop_data_assign, 2);
     rb_define_method(rb_cOutLoop, "start", ca_out_loop_data_start, 0);


### PR DESCRIPTION
now it is possible to set default output device like this:

```
# get audio devices
devs = CoreAudio.devices

# select target audio device
dev = (select device)

# set default output device
CoreAudio.set_default_output_device(dev)
```
