### PR TITLE
Add example for changing default sample rate

### DIFF
--- a/examples/set_def_out_sample_rate.rb
+++ b/examples/set_def_out_sample_rate.rb
@@ -1,0 +1,16 @@
+require "coreaudio"
+
+# Select option name device as default output device 
+def set_nominal_rate(rate)
+  available_rates = CoreAudio.default_output_device.available_sample_rate.flatten.uniq
+  rate = rate.to_f
+  if (!rate || !available_rates.member?(rate))
+    puts "Please enter a valid sample rate. Choose one of the following: #{available_rates.join(', ')}"
+		return -1
+	end
+
+	CoreAudio.default_output_device(nominal_rate: rate)
+	puts "Output device sample rate set to #{rate}"
+end
+
+set_nominal_rate(ARGV[0])


### PR DESCRIPTION
Whilst this is documented in `ext/coreaudio.m` it wasn't immediately
obvious. This commit includes a simple example to allow users to change
the default sample rate from the command line on OSX

Closes #16 